### PR TITLE
Fixes in skillStep, profile view, tagsStep

### DIFF
--- a/src/components/Feed/Suggestions.vue
+++ b/src/components/Feed/Suggestions.vue
@@ -30,7 +30,7 @@
 <script lang="ts">
 import Vue from "vue";
 import Contact from "@/components/Feed/Contact.vue";
-import { get } from "@/services/suggestedContact";
+import { getSuggestedContacts } from "@/services/suggestedContact";
 import { User } from "@/models/user";
 
 export default Vue.extend({
@@ -44,7 +44,7 @@ export default Vue.extend({
 
   methods: {
     async getSuggestedContacts() {
-      this.suggestedContacts = await get(10);
+      this.suggestedContacts = await getSuggestedContacts(10);
     },
     removeSuggestedContact(index: number) {
       this.suggestedContacts.splice(index, 1);

--- a/src/components/Onboarding/SuggestedContactsStep.vue
+++ b/src/components/Onboarding/SuggestedContactsStep.vue
@@ -45,7 +45,7 @@
 <script lang="ts">
 import Vue from "vue";
 import Contact from "@/components/Contact.vue";
-import { get } from "@/services/suggestedContact";
+import { getSuggestedContacts } from "@/services/suggestedContact";
 import { User } from "@/models/user";
 import NoData from "@/components/NoData.vue";
 
@@ -65,7 +65,7 @@ export default Vue.extend({
   },
 
   async created() {
-    const result = await get(10);
+    const result = await getSuggestedContacts(10);
     this.suggestedContacts = result;
   }
 });

--- a/src/components/Onboarding/TagStep.vue
+++ b/src/components/Onboarding/TagStep.vue
@@ -19,7 +19,12 @@
         v-for="(tag, index) in tags.slice(0, 4)"
         :key="tag.canonicalName"
       >
-        <TagComponent v-bind="{ ...tag }" @remove="removeTag(index)"></TagComponent>
+        <TagComponent
+          v-bind="{ ...tag }"
+          :isFollowed="false"
+          :isSelfProfile="true"
+          @remove="removeTag(index)"
+        ></TagComponent>
       </v-col>
     </transition-group>
     <v-row v-if="tags.length == 0" class="pb-md-8 pb-lg-12 pb-8" justify="center" no-gutters>

--- a/src/components/Profile/ProfilePreview.vue
+++ b/src/components/Profile/ProfilePreview.vue
@@ -1,6 +1,12 @@
 <template>
   <div>
-    <v-card class="card_profile" v-if="userDataComputed">
+    <v-sheet v-if="loading" color="grey lighten-4" class="pa-3">
+      <v-skeleton-loader
+        type="list-item-avatar, divider, list-item-three-line, card-heading, image, actions"
+      ></v-skeleton-loader>
+    </v-sheet>
+
+    <v-card class="card_profile" v-if="userDataComputed && !loading">
       <div class="d-flex justify-center mt-9">
         <v-avatar size="160">
           <v-img
@@ -153,7 +159,7 @@
       v-bind="{ ...userDataComputed }"
       v-if="createDialog"
       v-model="createDialog"
-      @confirmContactDeletion="deleteContact"
+      @deleteFromNetwork="deleteContact"
     ></DeleteContactDialog>
   </div>
 </template>
@@ -169,7 +175,7 @@ import DeleteContactDialog from "@/components/Profile/DeleteContactDialog.vue";
 export default Vue.extend({
   name: "ProfilePreview",
 
-  props: { userData: Object as PropType<Profile>, isSelfProfile: Boolean },
+  props: { userData: Object as PropType<Profile>, isSelfProfile: Boolean, loading: Boolean },
 
   components: { DeleteContactDialog },
 

--- a/src/components/Profile/Tabs/ProfileTabs.vue
+++ b/src/components/Profile/Tabs/ProfileTabs.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-card>
+  <v-sheet v-if="loading" color="grey lighten-4" class="pa-3">
+    <v-skeleton-loader type="list-item-three-line, card-heading, image"></v-skeleton-loader>
+  </v-sheet>
+
+  <v-card v-else>
     <v-tabs
       v-model="tab"
       background-color="transparent"
@@ -59,7 +63,7 @@ type TabsTitles = {
 export default Vue.extend({
   name: "ProfileTabs",
 
-  props: { isSelfProfile: Boolean },
+  props: { isSelfProfile: Boolean, loading: Boolean },
 
   components: {
     PostContainer,
@@ -99,14 +103,6 @@ export default Vue.extend({
       { tab: i18n.t("ViewProfile.Tags").toString(), content: TagsTab, icon: "mdi-pound" }
     ] as TabsTitles[]
   }),
-
-  /* created() {
-    if (!this.isSelfProfile) {
-      this.items = this.items.filter((item) => {
-        return item.name !== "network" && item.name !== "favorites";
-      });
-    }
-  }, */
 
   computed: {
     filteredTabs(): TabsTitles[] {

--- a/src/components/Profile/Tabs/TagsTab.vue
+++ b/src/components/Profile/Tabs/TagsTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-row align="center" justify="center" no-gutters class="mb-15">
+    <v-row align="center" justify="center" no-gutters class="mb-10">
       <v-col cols="8">
         <v-form>
           <v-combobox
@@ -86,7 +86,7 @@ export default Vue.extend({
     },
 
     async getTags(page: number) {
-      this.tagsPagination = await getTagsOfUser(this.$route.params.user, page, 1, this.search);
+      this.tagsPagination = await getTagsOfUser(this.$route.params.user, page, 5, this.search);
       this.currentPage = this.tagsPagination.currentPage + 1;
     },
 

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -16,7 +16,7 @@
             v-if="isFollowed && isSelfProfile"
             >{{ $i18n.t("unfollow") }}</v-btn
           >
-          <v-btn block color="primary" small @click="followTag" outlined v-if="!isFollowed && isSelfProfile">{{
+          <v-btn block color="primary" small @click="followTag" outlined v-if="!isFollowed">{{
             $i18n.t("Onboarding.Tag.follow")
           }}</v-btn>
         </v-col>

--- a/src/services/skill.ts
+++ b/src/services/skill.ts
@@ -2,11 +2,11 @@ import axios from "@/plugins/axios";
 import { Skill } from "@/models/skills";
 import { Pagination } from "@/models/Pagination/pagination";
 
-export async function get(skillName: string): Promise<Pagination<Skill>> {
+export async function getSkill(skillName: string): Promise<Pagination<Skill>> {
   const response = await axios.get(`/api/skills`, { params: { skillName } });
   return response.data;
 }
 
-export async function post(skill: Skill): Promise<void> {
+export async function postSkill(skill: Skill): Promise<void> {
   await axios.post(`/api/users/skills`, skill);
 }

--- a/src/services/suggestedContact.ts
+++ b/src/services/suggestedContact.ts
@@ -1,7 +1,7 @@
 import axios from "@/plugins/axios";
 import { User } from "@/models/user";
 
-export async function get(size: number): Promise<User[]> {
+export async function getSuggestedContacts(size: number): Promise<User[]> {
   const response = await axios.get(`/api/suggested-users`, { params: { size } });
   return response.data;
 }

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters class="mt-6">
     <v-col cols="12" md="6 offset-1" lg="3 offset-1" class="px-10">
-      <ProfilePreview :userData="userData" :isSelfProfile="isSelfProfile"></ProfilePreview>
+      <ProfilePreview :userData="userData" :isSelfProfile="isSelfProfile" :loading="loading"></ProfilePreview>
       <ReceivedContactRequests
         class="mt-8"
         @hideContactsRequests="showContactsRequests = false"
@@ -15,6 +15,7 @@
         :isSelfProfile="isSelfProfile"
         @decrementContact="decrementContacts"
         :userCanonicalName="userData"
+        :loading="loading"
       ></ProfileTabs>
     </v-col>
   </v-row>
@@ -36,7 +37,8 @@ export default Vue.extend({
   data: () => ({
     userData: {} as Profile,
     showContactsRequests: true,
-    isSelfProfile: false
+    isSelfProfile: false,
+    loading: true
   }),
 
   methods: {
@@ -51,6 +53,7 @@ export default Vue.extend({
   async created() {
     this.isSelfProfile = this.$route.params.user == this.$store.state.userModule.user.canonicalName;
     this.userData = await getUserByCanonicalName(this.$route.params.user);
+    this.loading = false;
   }
 });
 </script>


### PR DESCRIPTION
Borrar contacto desde su perfil, 
skeletons al ingresar a la vista Profile, 
arreglado el boton de follow en los tags en el Onboarding que se habían quitado por error,
Skillstep: buscar al tocar el combobox para mostrar opciones al comienzo cuando no se escribió nada. Se arregló que no se agreguen skills duplicadas.